### PR TITLE
Feat: 클라이언트측에서 면접 상태를 관리하도록 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,80 @@ npm build
 ## 폴더구조
 
 ```bash
+windows cmd command : tree src /f
+mac os cmd command : tree src 
+```
+
+```bash
 src
-│ App.js # 화면을 렌더링하는 골격 컴포넌트
-│ index.js # Start Point
+│  App.js
+│  index.js
+│
 ├─api
+│      interview.js
+│
 ├─assets
+│      free-icon-man-3884851-p-500.png
+│      free-icon-man-4086624-p-500.png
+│      pexels-fauxels-3182765_gnR1cf24-p-1080.webp
+│      recruitment-6838250_1920.png
+│
 ├─components
-├─constants # 상수 관리
+│      footer.jsx
+│      header.jsx
+│      loading.jsx
+│
+├─constants
+│      interviewChatConst.js
+│      interviewFeedbackConst.js
+│      interviewInputConst.js
+│      interviewRoomConst.js
+│      serviceConst.js
+│
 ├─fonts
+│      GmarketSansTTFBold.ttf
+│      GmarketSansTTFLight.ttf
+│      GmarketSansTTFMedium.ttf
+│      IBMPlexSansKR-Regular.ttf
+│      NanumGothic.ttf
+│
 ├─pages
-├─store # recoil 관련 폴더
+│  │  error_page.jsx
+│  │  interviewRoom.jsx
+│  │  main.jsx
+│  │
+│  └─interviewRoom
+│          interviewChat.jsx
+│          interviewFeedback.jsx
+│          interviewInput.jsx
+│
+├─store
+│      interviewChatAtom.js
+│      interviewRoomAtom.js
+│      loadingAtom.js
+│
 ├─styles
-└─utils # 공통 코드 관리
+│      animation.css
+│      button.hover.css
+│      error.module.css
+│      font.css
+│      footer.module.css
+│      header.module.css
+│      index.css
+│      interviewChat.module.css
+│      interviewFeedback.module.css
+│      interviewInput.module.css
+│      layout.css
+│      loading.css
+│      main.module.css
+│      radio.input.css
+│      range.input.css
+│      toast.css
+│
+└─utils
+        interviewSummaryGenerator.js
+        scrollRestoration.jsx
+        toastContainer.jsx
+        useInterval.js
+        useTitle.js
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.1",
         "react-scripts": "^5.0.1",
+        "react-spinners": "^0.13.8",
         "react-toastify": "^9.1.3",
         "recoil": "^0.7.7",
         "recoil-persist": "^5.1.0",
@@ -14130,6 +14131,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-spinners": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.8.tgz",
+      "integrity": "sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-toastify": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1",
     "react-scripts": "^5.0.1",
+    "react-spinners": "^0.13.8",
     "react-toastify": "^9.1.3",
     "recoil": "^0.7.7",
     "recoil-persist": "^5.1.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,17 @@
 import {Outlet} from "react-router-dom";
 import Header from "./components/header";
 import Footer from "./components/footer";
+import Loading from "./components/loading";
+import React from "react";
+import {useRecoilState} from "recoil";
+import {loadingAtom, loadingMessageAtom} from "./store/loadingAtom";
 
 function App(){
   // 모든 화면에 공통된 부분을 처리하는 컴포넌트
   // <Outlet/>은 라우터가 연결된 컴포넌트를 표시하는 영역
+
+  const [isLoading, ] = useRecoilState(loadingAtom);
+  const [loadingMessage, ] = useRecoilState(loadingMessageAtom);
   return(
     <div className={`wrapper`}>
       <div className={`contentWrapper`}>
@@ -12,6 +19,7 @@ function App(){
         <Outlet/>
       </div>
       <Footer/>
+      {isLoading ? <Loading message={loadingMessage} isLoading={isLoading} /> : null}
     </div>
   )
 }

--- a/src/api/interview.js
+++ b/src/api/interview.js
@@ -27,6 +27,7 @@ export const input_api = ({intervieweeName, companyName, jobGroup, recruitAnnoun
   // JSON 형식으로 requestBody 구성
   const requestBody = {
     "interviewee_name":intervieweeName,
+    "company_name":companyName,
     "job_group":jobGroup,
     "recruit_announcement":recruitAnnouncement,
     "cover_letter_questions":coverLetterQuestions,

--- a/src/api/interview.js
+++ b/src/api/interview.js
@@ -43,17 +43,22 @@ export const input_api = ({intervieweeName, companyName, jobGroup, recruitAnnoun
 };
 
 // 인터뷰 플래그에 따른 응답
-export const answer_api = ({question, answer}) => {
+export const answer_api = ({interview_id, question_id, question_content, answer_content}) => {
   // 입력 검증
-  if (typeof question !== 'string')
+  const regex = /^[a-z0-9]+$/;
+  if (!regex.test(interview_id)) throw new Error('Invalid input: Interview ID');
+  if (!regex.test(question_id)) throw new Error('Invalid input: Question ID');
+  if (typeof question_content !== 'string')
     throw new Error('Invalid input: Interviewer Question');
-  if (typeof answer !== 'string')
+  if (typeof answer_content !== 'string')
     throw new Error('Invalid input: Interviewee Answer');
 
   // JSON 형식으로 requestBody 구성
   const requestBody = {
-    "question": question,
-    "answer": answer,
+    "interview_id": interview_id,
+    "question_id": question_id,
+    "question_content": question_content,
+    "answer_content": answer_content,
   };
 
   return apiClient.post('/interview/answer', requestBody)

--- a/src/api/interview.js
+++ b/src/api/interview.js
@@ -68,6 +68,23 @@ export const answer_api = ({interview_id, question_id, question_content, answer_
   });
 };
 
+export const evaluation_api = ({interview_id}) => {
+  // 입력 검증
+  const regex = /^[a-z0-9]+$/;
+  if (!regex.test(interview_id)) throw new Error('Invalid input: Interview ID');
+
+  // JSON 형식으로 requestBody 구성
+  const requestBody = {
+    "interview_id": interview_id,
+  };
+
+  return apiClient.post('/interview/evaluation', requestBody)
+  .then(response => response.data)
+  .catch(error => {
+    throw error;
+  });
+}
+
 // 유저의 서비스평가를 받고, 종료
 export const feedback_api = ( {feedbacks} ) => {
   // 입력 검증

--- a/src/api/interview.js
+++ b/src/api/interview.js
@@ -86,14 +86,21 @@ export const evaluation_api = ({interview_id}) => {
 }
 
 // 유저의 서비스평가를 받고, 종료
-export const feedback_api = ( {feedbacks} ) => {
+export const feedback_api = ( {interview_id, question_ids, feedback_scores} ) => {
   // 입력 검증
-  if (!Array.isArray(feedbacks))
-    throw new Error('Invalid input: Feedback List');
+  const regex = /^[a-z0-9]+$/;
+  if (!regex.test(interview_id)) throw new Error('Invalid input: Interview ID');
+  if (!Array.isArray(question_ids)) throw new Error('Invalid input: Question IDs');
+  for (let question_id of question_ids) {
+    if (!regex.test(question_id)) throw new Error('Invalid input: Question ID');
+  }
+  if (!Array.isArray(feedback_scores)) throw new Error('Invalid input: Feedback Scores');
 
   // JSON 형식으로 requestBody 구성
   const requestBody = {
-    "feedbacks": feedbacks
+    "interview_id": interview_id,
+    "question_ids": question_ids,
+    "feedback_scores": feedback_scores,
   };
 
   return apiClient.post('/interview/feedback', requestBody)

--- a/src/api/interviewee.js
+++ b/src/api/interviewee.js
@@ -2,12 +2,12 @@ import axios from 'axios';
 
 // 기본 URL 설정
 const apiClient = axios.create({
-  baseURL: `${process.env.REACT_APP_API_ENDPOINT}/api/interviewee`,
+  baseURL: `${process.env.REACT_APP_API_ENDPOINT}`,
   withCredentials: true, // 쿠키(세션 ID)를 전달하기 위한 CORS 설정
 });
 
 export const session_api = () => {
-  return apiClient.post('/session')
+  return apiClient.post('/interview/session')
   .then(response => response.data)
   .catch(error => {
     throw error;
@@ -34,7 +34,7 @@ export const input_api = ({intervieweeName, companyName, jobGroup, recruitAnnoun
   };
 
   // response {flag,content}
-  return apiClient.post('/input', requestBody)
+  return apiClient.post('/interview/input', requestBody)
   .then(response => response.data)
   .catch(error => {
     throw error;
@@ -55,7 +55,7 @@ export const answer_api = ({question, answer}) => {
     "answer": answer,
   };
 
-  return apiClient.post('/answer', requestBody)
+  return apiClient.post('/interview/answer', requestBody)
   .then(response => response.data)
   .catch(error => {
     throw error;
@@ -73,7 +73,7 @@ export const feedback_api = ( {feedbacks} ) => {
     "feedbacks": feedbacks
   };
 
-  return apiClient.post('/feedback', requestBody)
+  return apiClient.post('/interview/feedback', requestBody)
   .catch(error => {
     throw error;
   });

--- a/src/api/interviewee.js
+++ b/src/api/interviewee.js
@@ -6,7 +6,7 @@ const apiClient = axios.create({
   withCredentials: true, // 쿠키(세션 ID)를 전달하기 위한 CORS 설정
 });
 
-export const session = () => {
+export const session_api = () => {
   return apiClient.post('/session')
   .then(response => response.data)
   .catch(error => {
@@ -15,9 +15,10 @@ export const session = () => {
 }
 
 // 자소서 분석, 초기 질문리스트 생성
-export const input = ({intervieweeName, jobGroup, recruitAnnouncement, coverLetterQuestions, coverLetterAnswers}) => {
+export const input_api = ({intervieweeName, companyName, jobGroup, recruitAnnouncement, coverLetterQuestions, coverLetterAnswers}) => {
   // 입력 검증
   if (typeof intervieweeName !== 'string') throw new Error("Invalid input: Interviewee Name");
+  if (typeof companyName !== 'string') throw new Error('Invalid input: Company Name')
   if (typeof jobGroup !== 'string') throw new Error('Invalid input: Job Group');
   if (typeof recruitAnnouncement !== 'string') throw new Error('Invalid input: Recruitment Announcement');
   if (!Array.isArray(coverLetterQuestions)) throw new Error('Invalid input: Cover Letter Questions');
@@ -41,7 +42,7 @@ export const input = ({intervieweeName, jobGroup, recruitAnnouncement, coverLett
 };
 
 // 인터뷰 플래그에 따른 응답
-export const answer = ({question, answer}) => {
+export const answer_api = ({question, answer}) => {
   // 입력 검증
   if (typeof question !== 'string')
     throw new Error('Invalid input: Interviewer Question');
@@ -62,7 +63,7 @@ export const answer = ({question, answer}) => {
 };
 
 // 유저의 서비스평가를 받고, 종료
-export const feedback = ( {feedbacks} ) => {
+export const feedback_api = ( {feedbacks} ) => {
   // 입력 검증
   if (!Array.isArray(feedbacks))
     throw new Error('Invalid input: Feedback List');

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -15,10 +15,10 @@ function HeaderMenu() {
   );
 }
 
-function InterviewMenu({intervieweeName="이름"}) {
+function InterviewMenu() {
   return (
     <>
-      <ul>{intervieweeName}</ul>
+      <ul>가상면접</ul>
     </>
   )
 }

--- a/src/components/loading.jsx
+++ b/src/components/loading.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import {SyncLoader} from "react-spinners";
+
+function Loading({ message, isLoading }) {
+  return (
+    <div className={`loading_modal ${isLoading ? 'active' : ''}`}>
+      <h3>{message}</h3>
+      <SyncLoader color="#fff"/>
+    </div>
+  )
+}
+
+export default Loading;

--- a/src/constants/interviewRoomConst.js
+++ b/src/constants/interviewRoomConst.js
@@ -15,4 +15,21 @@ const QUESTION_CATEGORY_LIST_VALUE = {
   "Personal Character Questions": ["Thinking Style and Behavioral Patterns", "Growth and Development", "Motivation and Values"]
 };
 
-export { INTERVIEW_INPUT_FORM_DEFAULT_VALUE, QUESTION_CATEGORY_LIST_VALUE };
+/** @type {{initialQuestions: *[], askedQuestions: *[], initialQuestionIndex: number, followupQuestionCount: number, lastContent: string, lastId: string}} */
+const INTERVIEW_STATE_DEFAULT_VALUE = {
+  "initialQuestions": [],
+  "askedQuestions": [],
+  "lastId": "",
+  "lastContent": "",
+  "initialQuestionIndex": 0,
+  "followupQuestionCount": 0,
+};
+
+const INTERVIEW_RESULT_DEFAULT_VALUE = {
+  interviewResults:[],
+  categoryScores: {},
+  categoryAverages: [],
+  categories: []
+}
+
+export { INTERVIEW_INPUT_FORM_DEFAULT_VALUE, QUESTION_CATEGORY_LIST_VALUE, INTERVIEW_STATE_DEFAULT_VALUE, INTERVIEW_RESULT_DEFAULT_VALUE };

--- a/src/constants/interviewRoomConst.js
+++ b/src/constants/interviewRoomConst.js
@@ -26,10 +26,8 @@ const INTERVIEW_STATE_DEFAULT_VALUE = {
 };
 
 const INTERVIEW_RESULT_DEFAULT_VALUE = {
-  interviewResults:[],
-  categoryScores: {},
-  categoryAverages: [],
-  categories: []
+  coverletterResults: [],
+  interviewResults: [],
 }
 
 export { INTERVIEW_INPUT_FORM_DEFAULT_VALUE, QUESTION_CATEGORY_LIST_VALUE, INTERVIEW_STATE_DEFAULT_VALUE, INTERVIEW_RESULT_DEFAULT_VALUE };

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import "./styles/layout.css";
 import "./styles/button.hover.css";
 import "./styles/radio.input.css";
 import "./styles/range.input.css";
+import "./styles/loading.css";
 import "react-toastify/dist/ReactToastify.css";
 import "./styles/toast.css";
 import Main from "./pages/main";

--- a/src/pages/interviewRoom/interviewChat.jsx
+++ b/src/pages/interviewRoom/interviewChat.jsx
@@ -14,7 +14,7 @@ import TypeIt from "typeit-react";
 import {useInterval} from "../../utils/useInterval";
 import {ScrollToTop} from "../../utils/scrollRestoration";
 import {chatHistoryAtom} from "../../store/interviewChatAtom";
-import {answer_api} from "../../api/interview";
+import {answer_api, evaluation_api} from "../../api/interview";
 import interviewSummaryGenerator from "../../utils/interviewSummaryGenerator";
 
 function TextareaForm({placeholder, item, onChange}){
@@ -149,10 +149,14 @@ function InterviewChat(){
 
           if(isInterviewEnded(res.message)){
             // INTERVIEW_END, 결과 페이지로 이동합니다.
-            handleInterviewerQuestion(null, "수고하셨습니다!");
-            setInterviewFlag(true);
-            console.log(res);
-            setInterviewResult(interviewSummaryGenerator(res.message.content)); // 결과내용을 interviewResultAtom에 저장합니다.
+            evaluation_api({interview_id: interviewId}).then((evaluation_result) => {
+              console.log(evaluation_result.message.evaluations);
+              handleInterviewerQuestion(null, "수고하셨습니다!");
+              setInterviewFlag(true);
+              setInterviewResult(interviewSummaryGenerator(evaluation_result.message.evaluations)); // 결과내용을 interviewResultAtom에 저장합니다.
+            }).catch((err2) => {
+              console.log(err2);
+            });
           }
           else{
             // NEXT_QUESTION, 다음 질문을 출력합니다.

--- a/src/pages/interviewRoom/interviewChat.jsx
+++ b/src/pages/interviewRoom/interviewChat.jsx
@@ -8,7 +8,7 @@ import TypeIt from "typeit-react";
 import {useInterval} from "../../utils/useInterval";
 import {ScrollToTop} from "../../utils/scrollRestoration";
 import {chatHistoryAtom} from "../../store/interviewChatAtom";
-import {answer} from "../../api/interviewee";
+import {answer_api} from "../../api/interview";
 import interviewSummaryGenerator from "../../utils/interviewSummaryGenerator";
 
 function TextareaForm({placeholder, item, onChange}){
@@ -62,7 +62,6 @@ function InterviewChat(){
   }
 
   const handleInterviewerQuestion = (e, questionContent) => {
-    // e.preventDefault();
     const question = {type:"AI", content: questionContent};
     setChatHistory([...chatHistory, question]);
     setInterviewerQuestion(questionContent);
@@ -77,7 +76,7 @@ function InterviewChat(){
       }
       else{
         // 유저의 답변이 완료되었을 때,
-        answer({question: interviewerQuestion, answer: intervieweeAnswer})
+        answer_api({question: interviewerQuestion, answer: intervieweeAnswer})
         .then((res) => {
           if(res.message.flag === "InterviewerActionEnum.END_INTERVIEW") {
             // INTERVIEW_END, 결과 페이지로 이동합니다.

--- a/src/pages/interviewRoom/interviewChat.jsx
+++ b/src/pages/interviewRoom/interviewChat.jsx
@@ -1,7 +1,13 @@
 import React, {useCallback, useRef, useState} from "react";
 import style from "../../styles/interviewChat.module.css";
 import {useRecoilState} from "recoil";
-import {interviewDataAtom, interviewResultAtom, roomIdAtom} from "../../store/interviewRoomAtom";
+import {
+  interviewDataAtom,
+  interviewIdAtom,
+  interviewResultAtom,
+  interviewStateAtom,
+  roomIdAtom
+} from "../../store/interviewRoomAtom";
 import AIProfileImage from "../../assets/free-icon-man-4086624-p-500.png";
 import HumanProfileImage from "../../assets/free-icon-man-3884851-p-500.png";
 import TypeIt from "typeit-react";
@@ -39,9 +45,11 @@ function InterviewChat(){
   const [interviewData, ] = useRecoilState(interviewDataAtom);
   const [chatHistory, setChatHistory] = useRecoilState(chatHistoryAtom); // 채팅내역
   const [, setInterviewResult] = useRecoilState(interviewResultAtom); // 인터뷰 결과
+  const [interviewId, ] = useRecoilState(interviewIdAtom);
+  const [interviewState, setInterviewState] = useRecoilState(interviewStateAtom);
+
   const [isTyping, setIsTyping] = useState(null); // isTyping: Optional[{index: index, type:item.type(AI or Human), instance:TypeIt instance}]
   const [intervieweeAnswerFormText, setIntervieweeAnswerFormText] = useState(""); // Form Value
-  const [interviewerQuestion, setInterviewerQuestion] = useState(""); // 면접관의 현재 질문 내용 (API로 보내기 위해 추적)
   const [intervieweeAnswer, setIntervieweeAnswer] = useState(""); // 사용자의 현재 질문에 대한 답변 내용
   const [interviewTurn, setInterviewTurn] = useState(false); // [false: AI 질문 중 true: Interviewee 답변 가능]
   const [interviewFlag, setInterviewFlag] = useState(false); // [false: 인터뷰 진행 중 true: 인터뷰 종료]
@@ -64,7 +72,58 @@ function InterviewChat(){
   const handleInterviewerQuestion = (e, questionContent) => {
     const question = {type:"AI", content: questionContent};
     setChatHistory([...chatHistory, question]);
-    setInterviewerQuestion(questionContent);
+  }
+
+  const isInterviewEnded = (followupQuestion) => {
+    if(interviewState.initialQuestionIndex >= interviewState.initialQuestions.length-1){
+      if(followupQuestion.question_id === null || interviewState.askedQuestions.length >= 15){
+        return true;
+      }
+    }
+    return false;
+  }
+
+  const setQuestionAsDone = (ask_idx) => {
+    const interviewStateCopy = JSON.parse(JSON.stringify(interviewState));
+    const question = interviewStateCopy.askedQuestions[ask_idx];
+    if(question.is_initial){
+      // 초기질문 리스트에서 해당하는 질문을 is_done으로 변경합니다.
+      const initialQuestionIndex = interviewStateCopy.initialQuestions.findIndex((item) => item._id === question._id);
+      interviewStateCopy.initialQuestions[initialQuestionIndex].is_done = true;
+    }
+    interviewStateCopy.askedQuestions[ask_idx].is_done = true;
+    interviewStateCopy.lastId = question._id;
+    interviewStateCopy.lastContent = question.content;
+    setInterviewState(interviewStateCopy);
+  }
+
+  const getNextQuestion = (followupQuestion) => {
+    const interviewStateCopy = JSON.parse(JSON.stringify(interviewState));
+    if(followupQuestion.question_id === null || interviewState.followupQuestionCount >= 3){
+      console.log("Next Initial Question");
+      // 다음 초기질문을 가져옵니다.
+      interviewStateCopy.initialQuestionIndex += 1;
+      interviewStateCopy.followupQuestionCount = 0;
+      const nextQuestion = interviewState.initialQuestions[interviewStateCopy.initialQuestionIndex];
+      interviewStateCopy.askedQuestions.push(nextQuestion);
+      setInterviewState(interviewStateCopy);
+      return nextQuestion;
+    }
+    else{
+      console.log("Next Followup Question");
+      // 생성된 꼬리질문을 가져옵니다.
+      interviewStateCopy.followupQuestionCount += 1;
+      const nextQuestion = {
+        _id: followupQuestion.question_id,
+        content: followupQuestion.question_content,
+        feedback: 0,
+        is_initial: false,
+        is_done: false
+      }
+      interviewStateCopy.askedQuestions.push(nextQuestion);
+      setInterviewState(interviewStateCopy);
+      return nextQuestion;
+    }
   }
 
   // 1초마다 입력이 완료되었는지 체크합니다.
@@ -75,10 +134,20 @@ function InterviewChat(){
         setInterviewTurn(true);
       }
       else{
+        const currentIndex = interviewState.askedQuestions.length-1;
+        const currentQuestion = interviewState.askedQuestions[currentIndex];
         // 유저의 답변이 완료되었을 때,
-        answer_api({question: interviewerQuestion, answer: intervieweeAnswer})
-        .then((res) => {
-          if(res.message.flag === "InterviewerActionEnum.END_INTERVIEW") {
+        answer_api({
+          interview_id: interviewId,
+          question_id: currentQuestion._id,
+          question_content: currentQuestion.content,
+          answer_content: intervieweeAnswer
+        }).then((res) => {
+          console.log("answer Api Success");
+          // 질문에 대한 답변을 성공적으로 보냈기 때문에 질문 상태를 갱신합니다.
+          setQuestionAsDone(currentIndex);
+
+          if(isInterviewEnded(res.message)){
             // INTERVIEW_END, 결과 페이지로 이동합니다.
             handleInterviewerQuestion(null, "수고하셨습니다!");
             setInterviewFlag(true);
@@ -87,7 +156,8 @@ function InterviewChat(){
           }
           else{
             // NEXT_QUESTION, 다음 질문을 출력합니다.
-            handleInterviewerQuestion(null, res.message.content);
+            const nextQuestion = getNextQuestion(res.message);
+            handleInterviewerQuestion(null, nextQuestion.content);
           }
         })
         .catch((err) => {

--- a/src/pages/interviewRoom/interviewFeedback.jsx
+++ b/src/pages/interviewRoom/interviewFeedback.jsx
@@ -7,7 +7,7 @@ import "chart.js/auto";
 import {FEEDBACK_RANGE_DEFAULT_VALUE} from "../../constants/interviewFeedbackConst";
 import {useNavigate} from "react-router-dom";
 import {ScrollToTop} from "../../utils/scrollRestoration";
-import {feedback} from "../../api/interviewee";
+import {feedback_api} from "../../api/interview";
 import {toast} from "react-toastify";
 
 // function RadarChart({labels, datasets}) {
@@ -94,7 +94,7 @@ function InterviewFeedback(){
 
   function handleEndButtonClick(e) {
     e.preventDefault();
-    feedback({feedbacks: interviewFeedbacks})
+    feedback_api({feedbacks: interviewFeedbacks})
     .then(res => {
       alert(`면접이 종료되었습니다.`);
       navigate("/");

--- a/src/pages/interviewRoom/interviewFeedback.jsx
+++ b/src/pages/interviewRoom/interviewFeedback.jsx
@@ -97,7 +97,7 @@ function InterviewFeedback(){
     e.preventDefault();
     feedback_api({
       interview_id: interviewId,
-      question_ids: [],
+      question_ids: interviewRecords.map(record => record.question_id),
       feedback_scores: interviewFeedbacks
     }).then(() => {
       alert(`면접이 종료되었습니다.`);

--- a/src/pages/interviewRoom/interviewFeedback.jsx
+++ b/src/pages/interviewRoom/interviewFeedback.jsx
@@ -135,11 +135,7 @@ function InterviewFeedback(){
                 </div>
                 <div>
                   <span>평가</span>
-                  <span>{record.analysis}</span>
-                </div>
-                <div>
-                  <span>점수</span>
-                  <span>{record.score}</span>
+                  <span>장점 분석<br/>{record.analysis[0]}<br/><br/>단점 분석<br/>{record.analysis[1]}</span>
                 </div>
               </div>
               <div className={`${style.feedback_box}`}>

--- a/src/pages/interviewRoom/interviewFeedback.jsx
+++ b/src/pages/interviewRoom/interviewFeedback.jsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import style from "../../styles/interviewFeedback.module.css";
 import {useRecoilState} from "recoil";
-import {interviewDataAtom, interviewResultAtom} from "../../store/interviewRoomAtom";
+import {interviewDataAtom, interviewIdAtom, interviewResultAtom} from "../../store/interviewRoomAtom";
 import "chart.js/auto";
 // import { Radar } from "react-chartjs-2";
 import {FEEDBACK_RANGE_DEFAULT_VALUE} from "../../constants/interviewFeedbackConst";
@@ -81,6 +81,7 @@ function InterviewFeedback(){
   const navigate = useNavigate();
   const [interviewData, ] = useRecoilState(interviewDataAtom);
   const [interviewResults, ] = useRecoilState(interviewResultAtom);
+  const [interviewId, ] = useRecoilState(interviewIdAtom);
   const [interviewRecords, setInterviewRecords] = useState([]);
   const [interviewFeedbacks, setInterviewFeedbacks] = useState([]);
 
@@ -94,8 +95,11 @@ function InterviewFeedback(){
 
   function handleEndButtonClick(e) {
     e.preventDefault();
-    feedback_api({feedbacks: interviewFeedbacks})
-    .then(res => {
+    feedback_api({
+      interview_id: interviewId,
+      question_ids: [],
+      feedback_scores: interviewFeedbacks
+    }).then(() => {
       alert(`면접이 종료되었습니다.`);
       navigate("/");
     })

--- a/src/pages/interviewRoom/interviewInput.jsx
+++ b/src/pages/interviewRoom/interviewInput.jsx
@@ -4,7 +4,7 @@ import {MAXIMUM_COVERLETTER_NUMBER} from "../../constants/interviewInputConst";
 import {useRecoilState} from "recoil";
 import {interviewDataAtom, roomIdAtom} from "../../store/interviewRoomAtom";
 import {ScrollToTop} from "../../utils/scrollRestoration";
-import {input, session} from "../../api/interviewee";
+import {input_api, session_api} from "../../api/interview";
 import {toast} from "react-toastify";
 import {chatHistoryAtom} from "../../store/interviewChatAtom";
 import {CHAT_HISTORY_DEFAULT_VALUE} from "../../constants/interviewChatConst";
@@ -216,10 +216,11 @@ function InterviewInput(){
 
     // REFACTORING: 원래 이렇게 지져분하게 안짜고 싶었는데, promise 방식을 쓰고 있어서인지
     // try-catch문으로 error가 안잡혀서 아래와 같이 처리했습니다. 리팩토링 해야함...
-    session().then(() => {
+    session_api().then(() => {
       // session을 성공적으로 생성했을 때, input API를 호출합니다.
-      input({
+      input_api({
         intervieweeName: intervieweeName,
+        companyName: interviewTargetCompany,
         jobGroup: interviewTargetPosition,
         recruitAnnouncement: interviewRecruitment,
         coverLetterQuestions: coverLettersCopy.map(({question, content}) => question),

--- a/src/pages/interviewRoom/interviewInput.jsx
+++ b/src/pages/interviewRoom/interviewInput.jsx
@@ -9,6 +9,7 @@ import {toast} from "react-toastify";
 import {chatHistoryAtom} from "../../store/interviewChatAtom";
 import {CHAT_HISTORY_DEFAULT_VALUE} from "../../constants/interviewChatConst";
 import {INTERVIEW_STATE_DEFAULT_VALUE} from "../../constants/interviewRoomConst";
+import {loadingAtom, loadingMessageAtom} from "../../store/loadingAtom";
 
 
 function InputForm({placeholder, item, index, onChange}){
@@ -161,6 +162,8 @@ function CoverLetterComponent({coverLetters, setCoverLetters}){
 
 function InterviewInput(){
   ScrollToTop();
+  const [, setIsLoading] = useRecoilState(loadingAtom);
+  const [, setLoadingMessage] = useRecoilState(loadingMessageAtom);
   // 사용자의 화면을 변경하기 위한 RoomID
   const [, setRoomID] = useRecoilState(roomIdAtom);
   // 사용자에게 입력받은 데이터를 전역상태로 저장
@@ -170,7 +173,7 @@ function InterviewInput(){
   // Interview ID
   const [, setInterviewId] = useRecoilState(interviewIdAtom);
   // 클라이언트 상태 관리
-  const [interviewState, setInterviewState] = useRecoilState(interviewStateAtom);
+  const [, setInterviewState] = useRecoilState(interviewStateAtom);
 
   // 사용자에게서 입력받는 데이터들
   const [intervieweeName, setIntervieweeName] = useState(""); // 지원자 이름
@@ -224,6 +227,8 @@ function InterviewInput(){
     // try-catch문으로 error가 안잡혀서 아래와 같이 처리했습니다. 리팩토링 해야함...
     session_api().then(() => {
       // session을 성공적으로 생성했을 때, input API를 호출합니다.
+      setIsLoading(true);
+      setLoadingMessage("잠시후 면접이 시작됩니다");
       input_api({
         intervieweeName: intervieweeName,
         companyName: interviewTargetCompany,
@@ -233,6 +238,7 @@ function InterviewInput(){
         coverLetterAnswers: coverLettersCopy.map(({question, content}) => content)
       })
       .then((res) => {
+        setIsLoading(false);
         setRoomID("interviewChat");
         const interviewStateCopy = JSON.parse(JSON.stringify(INTERVIEW_STATE_DEFAULT_VALUE));
         interviewStateCopy.askedQuestions = [];
@@ -250,6 +256,7 @@ function InterviewInput(){
         setChatHistory([...CHAT_HISTORY_DEFAULT_VALUE, {type:"AI", content:firstQuestion.content}]);
       })
       .catch((err) => {
+        setIsLoading(false);
         toast.error(`오류가 발생했습니다!\n${err.message}`, {});
       });
 

--- a/src/store/interviewChatAtom.js
+++ b/src/store/interviewChatAtom.js
@@ -8,11 +8,7 @@ const {persistAtom} = recoilPersist();
 // VSCode IDE에서도 Ctrl + 좌클릭으로 참조중인 위치를 추적할 수 있네요.
 export const chatHistoryAtom = atom({
   key: "chatHistoryState",
+  /** @type {Array<{type:string, content: string}>} */
   default: CHAT_HISTORY_DEFAULT_VALUE,
-  // list({type:"AI" or "Human", content: string}, ...)
-  // CHAT_HISTORY_DEFAULT_VALUE = [
-  // {type:"AI",
-  //  content: "안녕하세요. 저는 인공지능 면접관입니다. 제가 질문을 하면 답변을 작성하여 제출해주시면 됩니다."}
-  // ]
   effects_UNSTABLE: [persistAtom],
 });

--- a/src/store/interviewRoomAtom.js
+++ b/src/store/interviewRoomAtom.js
@@ -28,6 +28,21 @@ export const interviewDataAtom = atom({
   effects_UNSTABLE: [persistAtom],
 });
 
+
+export const interviewQuestionAtom = atom({
+  key: "interviewQuestionState",
+  default: {
+    /** @type {Array<{_id: string, content: string, feedback: number, is_initial: boolean, is_done: boolean}>} */
+    "initialQuestions": [],
+    "askedQuestions": [],
+    "lastIndex": 0,
+    "lastContent": "",
+    "initialQuestionIndex": 0,
+    "followupQuestionCount": 0,
+  },
+  effects_UNSTABLE: [persistAtom],
+})
+
 export const interviewResultAtom = atom({
   key: "interviewResultState",
   default: {interviewResults:[], categoryScores: {}, categoryAverages: [], categories: []},

--- a/src/store/interviewRoomAtom.js
+++ b/src/store/interviewRoomAtom.js
@@ -58,7 +58,7 @@ export const interviewResultAtom = atom({
   key: "interviewResultState",
   /** @type {{
    * coverletterResults: Array<{question: string, answer: string, analysis: string}>,
-   * interviewResults: Array<{question: string, answer: string, analysis: string}>}}*/
+   * interviewResults: Array<{question_id: string, question: string, answer: string, analysis: string}>}}*/
   default: INTERVIEW_RESULT_DEFAULT_VALUE,
   effects_UNSTABLE: [persistAtom],
 });

--- a/src/store/interviewRoomAtom.js
+++ b/src/store/interviewRoomAtom.js
@@ -57,11 +57,8 @@ export const interviewIdAtom = atom({
 export const interviewResultAtom = atom({
   key: "interviewResultState",
   /** @type {{
-   * interviewResults: Array<{question: string, answer: string, category: string, score: number, analysis: string}>,
-   * categoryScores: {},
-   * categoryAverages: [],
-   * categories: []}}
-   */
+   * coverletterResults: Array<{question: string, answer: string, analysis: string}>,
+   * interviewResults: Array<{question: string, answer: string, analysis: string}>}}*/
   default: INTERVIEW_RESULT_DEFAULT_VALUE,
   effects_UNSTABLE: [persistAtom],
 });

--- a/src/store/interviewRoomAtom.js
+++ b/src/store/interviewRoomAtom.js
@@ -1,6 +1,10 @@
 import {atom} from "recoil";
 import {recoilPersist} from "recoil-persist";
-import {INTERVIEW_INPUT_FORM_DEFAULT_VALUE} from "../constants/interviewRoomConst";
+import {
+  INTERVIEW_INPUT_FORM_DEFAULT_VALUE,
+  INTERVIEW_RESULT_DEFAULT_VALUE,
+  INTERVIEW_STATE_DEFAULT_VALUE
+} from "../constants/interviewRoomConst";
 
 /*
 key: 키는 해당 전역변수를 구분하기 위한 유니크값
@@ -12,6 +16,7 @@ const {persistAtom} = recoilPersist();
 
 export const roomIdAtom = atom({
   key: "roomIDState",
+  /** @type {string} */
   default: "interviewChat",
   effects_UNSTABLE: [persistAtom],
 });
@@ -29,22 +34,34 @@ export const interviewDataAtom = atom({
 });
 
 
-export const interviewQuestionAtom = atom({
-  key: "interviewQuestionState",
-  default: {
-    /** @type {Array<{_id: string, content: string, feedback: number, is_initial: boolean, is_done: boolean}>} */
-    "initialQuestions": [],
-    "askedQuestions": [],
-    "lastIndex": 0,
-    "lastContent": "",
-    "initialQuestionIndex": 0,
-    "followupQuestionCount": 0,
-  },
+export const interviewStateAtom = atom({
+  key: "interviewStateState",
+  /** @type {{
+   * initialQuestions: Array<{_id: string, content: string, feedback: number, is_initial: boolean, is_done: boolean}>,
+   * askedQuestions: Array<{_id: string, content: string, feedback: number, is_initial: boolean, is_done: boolean}>,
+   * lastId: string,
+   * lastContent: string,
+   * initialQuestionIndex: number,
+   * followupQuestionCount: number}}*/
+  default: INTERVIEW_STATE_DEFAULT_VALUE,
+  effects_UNSTABLE: [persistAtom],
+});
+
+export const interviewIdAtom = atom({
+  key: "interviewIdState",
+  /** @type {string} */
+  default: "",
   effects_UNSTABLE: [persistAtom],
 })
 
 export const interviewResultAtom = atom({
   key: "interviewResultState",
-  default: {interviewResults:[], categoryScores: {}, categoryAverages: [], categories: []},
+  /** @type {{
+   * interviewResults: Array<{question: string, answer: string, category: string, score: number, analysis: string}>,
+   * categoryScores: {},
+   * categoryAverages: [],
+   * categories: []}}
+   */
+  default: INTERVIEW_RESULT_DEFAULT_VALUE,
   effects_UNSTABLE: [persistAtom],
 });

--- a/src/store/interviewRoomAtom.js
+++ b/src/store/interviewRoomAtom.js
@@ -18,14 +18,13 @@ export const roomIdAtom = atom({
 
 export const interviewDataAtom = atom({
   key: "interviewDataState",
+  /** @type {{
+   * intervieweeName: string,
+   * interviewTargetCompany: string,
+   * interviewTargetPosition: string,
+   * interviewRecruitment: string,
+   * interviewCoverLetters: Array<{question: string, content: string}>}}*/
   default: INTERVIEW_INPUT_FORM_DEFAULT_VALUE,
-  // INTERVIEW_INPUT_FORM_DEFAULT_VALUE = {
-  //   "intervieweeName": "",
-  //   "interviewTargetCompany": "",
-  //   "interviewTargetPosition": "",
-  //   "interviewRecruitment": "",
-  //   "interviewCoverLetters": [],
-  // }
   effects_UNSTABLE: [persistAtom],
 });
 

--- a/src/store/loadingAtom.js
+++ b/src/store/loadingAtom.js
@@ -1,0 +1,13 @@
+import {atom} from "recoil";
+
+export const loadingAtom = atom({
+  key: "loadingState",
+  /** @type {boolean} */
+  default: false,
+});
+
+export const loadingMessageAtom = atom({
+  key: "loadingMessageState",
+  /** @type {string} */
+  default: "",
+});

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -37,6 +37,7 @@ button {
 }
 
 section {
+    box-sizing: border-box;
     padding-top: 30px;
     padding-bottom: 30px;
 }

--- a/src/styles/loading.css
+++ b/src/styles/loading.css
@@ -1,0 +1,30 @@
+@keyframes Dimming {
+    0% {
+        background: rgba(0, 0, 0, 0);
+        color: rgba(255, 255, 255, 0);
+        display: flex;
+    }
+    to {
+        background: rgba(0, 0, 0, 0.7);
+        color: rgba(255, 255, 255, 1);
+    }
+}
+
+.loading_modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    font-family: "GmarketSansBold";
+    font-size: 1.5rem;
+    font-weight: 500;
+    user-select: none;
+    z-index: 1000;
+    animation:Dimming 1s;
+    animation-fill-mode: forwards;
+}

--- a/src/utils/interviewSummaryGenerator.js
+++ b/src/utils/interviewSummaryGenerator.js
@@ -1,53 +1,13 @@
-import {QUESTION_CATEGORY_LIST_VALUE} from "../constants/interviewRoomConst";
-
-function ParsingCategory(categoryString){
-  const category = QUESTION_CATEGORY_LIST_VALUE; // CATEGORY LIST
-  // category의 key들을 순환하면서 categoryString에 포함되어 있는지 확인.
-  for (let key in category) {
-    if(categoryString.includes(key)) {
-      for (let i = 0; i < category[key].length; i++) {
-        if(categoryString.includes(category[key][i])){
-          return {mainCategory: key, subCategory: category[key][i]};
-        }
-      }
-    }
-  }
-  return {mainCategory: null, subCategory: null};
-}
+import {INTERVIEW_RESULT_DEFAULT_VALUE} from "../constants/interviewRoomConst";
 
 
 function interviewSummaryGenerator(interviewResults){
-  const parsingInterviewResults = [];
-  const categoryScores = {};
-  const categoryAverages = [];
-  const categories = [];
-  for (const key in QUESTION_CATEGORY_LIST_VALUE) {
-    // 동적으로 객체 속성을 대분류로 생성
-    categoryScores[key] = [];
-    categories.push(key);
-  }
-
-  for(let i = 0; i < interviewResults.length; i++){
-    const item = interviewResults[i];
-    item[2] = ParsingCategory(item[2]);
-    const parsedItem ={question: item[0], answer: item[1], category: item[2], score: item[3], analysis: item[4]}; //score: parseInt(item[3]),
-    // categoryScores[parsedItem.category.mainCategory].push(parsedItem.score);
-    parsingInterviewResults.push(parsedItem);
-  }
-
-  for (const key in categoryScores) {
-    const categoryScore = categoryScores[key];
-    const categoryScoreSum = categoryScore.reduce((a, b) => a + b, 0);
-    const categoryScoreAverage = Math.round(categoryScoreSum / categoryScore.length);
-    categoryAverages.push(categoryScoreAverage);
-  }
-
-  const interviewSummary = {
-    interviewResults: parsingInterviewResults,
-    categoryScores: categoryScores,
-    categoryAverages: categoryAverages,
-    categories: categories
-  };
+  const interviewSummary = JSON.parse(JSON.stringify(INTERVIEW_RESULT_DEFAULT_VALUE));
+  interviewSummary.interviewResults = interviewResults.map(result => ({
+    question: result.question,
+    answer: result.answer,
+    analysis: result.evaluation
+  }));
   return interviewSummary;
 }
 

--- a/src/utils/interviewSummaryGenerator.js
+++ b/src/utils/interviewSummaryGenerator.js
@@ -4,6 +4,7 @@ import {INTERVIEW_RESULT_DEFAULT_VALUE} from "../constants/interviewRoomConst";
 function interviewSummaryGenerator(interviewResults){
   const interviewSummary = JSON.parse(JSON.stringify(INTERVIEW_RESULT_DEFAULT_VALUE));
   interviewSummary.interviewResults = interviewResults.map(result => ({
+    question_id: result.question_id,
     question: result.question,
     answer: result.answer,
     analysis: result.evaluation


### PR DESCRIPTION
## 상태 관리 로직 추가

1. 모든 질문과 답변을 클라이언트 측에서 관리함.
2. 질문이 15개 이상이거나 초기질문이 전부 출제되었다면 면접이 종료됨.
3. 꼬리질문은 3개 이상 출제되었을 때 강제로 초기질문으로 넘어감.
4. 꼬리질문 관련해서 https://github.com/SWM14-Architect/moview-core-service/issues/94 이슈가 해결되면 함께 반영해야함.

## Loading 연출 추가

1. 사용자가 초기데이터를 입력하고 면접을 시작할 때, 면접이 종료될 때 시간이 오래걸리는 부분에 로딩 추가
2. 로딩 중에는 모든 상호작용을 금지함.

## Recoil 관련 주석과 상수 개선

1. Recoil에서 persist 옵션이 붙은 상태변수는 한번 변수에 값이 기록되면 그 값이 계속 유지가 됨.
2. 그렇다보니, 매번 면접을 새롭게 시작할 때마다 초기화를 해주는 코드가 필요함.
3. 초기값을 상수로 따로빼서 초기화해줄 때도 해당 상수를 불러와서 대입하는 식으로 해결.
4. 주석은 JavaScript 방식으로 재작성함.