### PR TITLE
fix: 글자수 제한에 의해 글자가 제거 되었을 때 textarea height resize가 정상적으로 작동하지 않던 문제 해결

### DIFF
--- a/src/pages/interviewRoom/interviewChat.jsx
+++ b/src/pages/interviewRoom/interviewChat.jsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useRef, useState} from "react";
+import React, {useEffect, useRef, useState} from "react";
 import style from "../../styles/interviewChat.module.css";
 import {useRecoilState} from "recoil";
 import { toast } from "react-toastify";
@@ -26,17 +26,16 @@ function TextareaForm({ placeholder, item, onChange }){
   const textRef = useRef(null);
 
   // Textarea height auto resize
-  const handleResizeHeight = useCallback(() => {
+  useEffect(() => {
     textRef.current.style.height = "auto";
     textRef.current.style.height = textRef.current.scrollHeight + "px";
-  }, []);
+  }, [item]);
 
   return (
     <textarea
       ref={textRef}
       className={`${style.input_form_textbox}`}
       placeholder={placeholder}
-      onInput={handleResizeHeight}
       onChange={e => onChange(e)}
       value={item}
     />

--- a/src/pages/interviewRoom/interviewInput.jsx
+++ b/src/pages/interviewRoom/interviewInput.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import style from "../../styles/interviewInput.module.css";
 import {
   MAXIMUM_COVERLETTER_NUMBER,
@@ -54,17 +54,16 @@ function TextareaForm({ placeholder, item, index, onChange, styles = {} }) {
   const textRef = useRef(null);
 
   // Textarea height auto resize
-  const handleResizeHeight = useCallback(() => {
+  useEffect(() => {
     textRef.current.style.height = "auto";
     textRef.current.style.height = textRef.current.scrollHeight + "px";
-  }, []);
+  }, [item]);
 
   return (
     <textarea
       ref={textRef}
       className={`${style.input_form_textbox}`}
       placeholder={placeholder}
-      onInput={handleResizeHeight}
       onChange={(e) => (index !== null ? onChange(e, index) : onChange(e))}
       style={styles}
       value={item}
@@ -366,7 +365,7 @@ function InterviewInput() {
       })
       .catch((err) => {
         setIsLoading(false);
-        if (err?.response.status === 401) {
+        if (err.response?.status === 401) {
           toast.info("다시 로그인을 해주세요.");
         } else {
           toast.error(`${err.response?.data.message ? err.response.data.message.error : "오류가 발생했습니다!\n" + err.message}`, {});

--- a/src/pages/interviewRoom/interviewLightInput.jsx
+++ b/src/pages/interviewRoom/interviewLightInput.jsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useRef, useState} from "react";
+import React, {useEffect, useRef, useState} from "react";
 import style from "../../styles/interviewInput.module.css";
 import { useRecoilState } from "recoil";
 import {
@@ -268,17 +268,16 @@ function TextareaForm({ placeholder, item, index, onChange, styles = {} }) {
   const textRef = useRef(null);
 
   // Textarea height auto resize
-  const handleResizeHeight = useCallback(() => {
+  useEffect(() => {
     textRef.current.style.height = "auto";
     textRef.current.style.height = textRef.current.scrollHeight + "px";
-  }, []);
+  }, [item]);
 
   return (
     <textarea
       ref={textRef}
       className={`${style.input_form_textbox}`}
       placeholder={placeholder}
-      onInput={handleResizeHeight}
       onChange={(e) => (index !== null ? onChange(e, index) : onChange(e))}
       style={styles}
       value={item}


### PR DESCRIPTION
## textarea height resize
- 기존에 useCallback으로 작동하던 resizing 로직을 useEffect를 이용하도록 변경